### PR TITLE
remove support for plain-text password

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,13 @@ where `my-auth-file.txt` contains
       region: eu-west-1
       bucket: my-bucket
     users:
-      erik:
-        password: "my%secret%password"
-      peter:
-        # If you want to obfuscate a password, you can put it in here base64-encoded.
-        password: !!binary |
-          aGVqCg==
       arnold:
         hash:
           salt: ksdfkdsj
+          sha256: fd853dc703b2b67b0bcaffdf357685fb6480837c3e6e537526e71b858d6a38f8
+      peter:
+        hash:
+          salt: ffkfkdsj
           sha256: fd853dc703b2b67b0bcaffdf357685fb6480837c3e6e537526e71b858d6a38f8
 
 You can generate a sample documentation using `./s3-basic-auth-proxy serve generate`.

--- a/main.go
+++ b/main.go
@@ -39,8 +39,7 @@ type Config struct {
 		Bucket string
 	}
 	Users map[string]struct {
-		Password string
-		Hash     struct {
+		Hash struct {
 			Salt   string
 			Sha256 string
 		}
@@ -132,10 +131,7 @@ func checkCredentials(c Config, inputUsername, inputPassword string) bool {
 			continue
 		}
 
-		if userdata.Password != "" && inputPassword == userdata.Password {
-			return true
-		}
-		if userdata.Hash.Sha256 != "" && calculateSha256(userdata.Hash.Salt, inputPassword) == userdata.Hash.Sha256 {
+		if calculateSha256(userdata.Hash.Salt, inputPassword) == userdata.Hash.Sha256 {
 			return true
 		}
 	}


### PR DESCRIPTION
Simply not best-pracise to store it. Shouldn't promote it.
